### PR TITLE
php 7.1 fixes

### DIFF
--- a/src/Devristo/Phpws/Protocol/WebSocketTransport.php
+++ b/src/Devristo/Phpws/Protocol/WebSocketTransport.php
@@ -61,7 +61,7 @@ abstract class WebSocketTransport extends EventEmitter implements WebSocketTrans
             $that->handleData($buffer);
         });
 
-        $socket->on("close", function($data) use ($that){
+        $socket->on("close", function($data = null) use ($that){
             $that->emit("close", func_get_args());
         });
     }

--- a/src/Devristo/Phpws/Server/WebSocketServer.php
+++ b/src/Devristo/Phpws/Server/WebSocketServer.php
@@ -151,7 +151,7 @@ class WebSocketServer extends EventEmitter
                 $that->emit("message", array("client" => $connection, "message" => $message));
             });
 
-            $client->on("close", function () use ($that, $client, $logger, &$sockets, $client) {
+            $client->on("close", function () use ($that, $client, $logger, &$sockets) {
                 $sockets->detach($client);
                 $connection = $client->getTransport();
 


### PR DESCRIPTION
Prevents this:
`
6/15/2018 5:25:43 AM Too few arguments to function Devristo\Phpws\Protocol\WebSocketTransport::Devristo\Phpws\Protocol\{closure}(), 0 passed in ../vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php on line 123 and exactly 1 expected
6/15/2018 5:25:43 AM ../vendor/mpociot/phpws/src/Devristo/Phpws/Protocol/WebSocketTransport.php:64
6/15/2018 5:25:43 AM#0 ../vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php(123): Devristo\Phpws\Protocol\WebSocketTransport->Devristo\Phpws\Protocol\{closure}()
6/15/2018 5:25:43 AM#1 ../vendor/react/stream/src/Util.php(71): Evenement\EventEmitter->emit('close', Array)
6/15/2018 5:25:43 AM#2 ../vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php(123): React\Stream\Util::React\Stream\{closure}()
6/15/2018 5:25:43 AM#3 ../vendor/react/stream/src/DuplexResourceStream.php(138): Evenement\EventEmitter->emit('close')
6/15/2018 5:25:43 AM#4 ../vendor/react/stream/src/DuplexResourceStream.php(197): React\Stream\DuplexResourceStream->close()
6/15/2018 5:25:43 AM#5 [internal function]: React\Stream\DuplexResourceStream->handleData(Resource id #277, Object(React\EventLoop\StreamSelectLoop))
6/15/2018 5:25:43 AM#6 ../vendor/react/event-loop/src/StreamSelectLoop.php(236): call_user_func(Array, Resource id #277, Object(React\EventLoop\StreamSelectLoop))
6/15/2018 5:25:43 AM#7 ../vendor/react/event-loop/src/StreamSelectLoop.php(205): React\EventLoop\StreamSelectLoop->waitForStreamActivity(NULL)`