### PR TITLE
Add  usage of DNS_SERVER env variable

### DIFF
--- a/src/Devristo/Phpws/Client/Connector.php
+++ b/src/Devristo/Phpws/Client/Connector.php
@@ -53,7 +53,9 @@ class Connector implements ConnectorInterface
             } else {
                 $factory = new Factory();
                 $resolver = $factory->create(
-                    $options['dns'] === true ? '8.8.8.8' : $options['dns'],
+                    $options['dns'] === true
+                        ? (false === getenv('DNS_SERVER') ? '8.8.8.8' : getenv('DNS_SERVER'))
+                        : $options['dns'],
                     $loop
                 );
             }


### PR DESCRIPTION
Hi there,

just stumpled over this, in the Websocket Class its used but not in the Connector Class. This created DNS resolution problems when behind a firewall blocking access to 8.8.8.8 :)